### PR TITLE
feat: Add native macOS build support with git worktree enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,10 @@ RUN npm install -g @anthropic-ai/claude-code
 ENV PATH="/usr/local/bin:${PATH}"
 
 # Create directories for configuration
-RUN mkdir -p /app/.claude /home/claude-user/.claude
+RUN mkdir -p /app/.claude /home/claude-user/.claude /home/claude-user/scripts
+
+# Copy scripts
+COPY scripts/* /home/claude-user/scripts
 
 # Copy startup script
 COPY src/startup.sh /app/

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Build and run
+set -euo pipefail
+trap 'echo "$0: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
 # ABOUTME: Startup script for claude-docker container with MCP server
 # ABOUTME: Loads twilio env vars, checks for .credentials.json, copies CLAUDE.md template if no claude.md in claude-docker/claude-home.
 # ABOUTME: Starts claude code with permissions bypass and continues from last session.
@@ -43,11 +46,11 @@ fi
 echo "Checking macOS native build support..."
 if [ "${ENABLE_MACOS_BUILDS:-false}" = "true" ]; then
     if command -v python3 >/dev/null 2>&1 && [ -f "/home/claude-user/scripts/macos_builder.py" ]; then
-        BUILD_STATUS=$(python3 /home/claude-user/scripts/macos_builder.py status 2>/dev/null)
+        BUILD_STATUS=$(python3 /home/claude-user/scripts/macos_builder.py status 2>/dev/null || true)
         if echo "$BUILD_STATUS" | grep -q "Connection Available: True"; then
             echo "✓ macOS native builds available"
-            PROJECT_TYPE=$(echo "$BUILD_STATUS" | grep "Project Type:" | cut -d: -f2- | xargs)
-            CONFIGURED_COMMANDS=$(echo "$BUILD_STATUS" | grep "Configured Commands:" | cut -d: -f2- | xargs)
+            PROJECT_TYPE=$(echo "$BUILD_STATUS" | grep "Project Type:" | cut -d: -f2- | xargs || true)
+            CONFIGURED_COMMANDS=$(echo "$BUILD_STATUS" | grep "Configured Commands:" | cut -d: -f2- | xargs || true)
             echo "  Project: $PROJECT_TYPE"
             echo "  Commands: $CONFIGURED_COMMANDS"
         else


### PR DESCRIPTION
Your MacOS changes are GREAT, thanks!

I made some minor changes to fix a problem where the scripts were missing in the docker image. I also have a PR against the upstream repo to support "bash strict mode", and so I made several changes to your script so that it also works in strict mode. Cheers!